### PR TITLE
Grammar fixes

### DIFF
--- a/src/main/java/me/moomoo/anarchyexploitfixes/patches/CrashExploits.java
+++ b/src/main/java/me/moomoo/anarchyexploitfixes/patches/CrashExploits.java
@@ -23,7 +23,7 @@ public class CrashExploits implements Listener {
         if (config.getBoolean("PreventEndGatewayCrashExploit")) {
             if (evt.getEntity().getWorld().getEnvironment().equals(World.Environment.THE_END) && !evt.getEntity().isEmpty()) {
                 evt.setCancelled(true);
-                plugin.getLogger().warning("Prevented the end gateway crash exploit! Prevented a entity " + "(" + evt.getEntity().getName() + ")" + " from going through end gateway at " + evt.getEntity().getLocation());
+                plugin.getLogger().warning("Prevented the end gateway crash exploit! Prevented an entity " + "(" + evt.getEntity().getName() + ")" + " from going through an end gateway at " + evt.getEntity().getLocation());
             }
         }
 


### PR DESCRIPTION
## Overview
Small grammar fix in `CrashExploits.java` changing `a` to `an`.