### PR TITLE
Add AntiSpamCommandsWhitelist config option

### DIFF
--- a/src/main/java/me/moomoo/anarchyexploitfixes/misc/Chat.java
+++ b/src/main/java/me/moomoo/anarchyexploitfixes/misc/Chat.java
@@ -96,10 +96,13 @@ public class Chat implements Listener {
 
     @EventHandler
     private void onPreProcess(PlayerCommandPreprocessEvent event) {
-        if (plugin.getConfig().getBoolean("AntiSpamCommands")) {
-            if (handleChatSpam(event.getPlayer(), event.getMessage())) {
-                event.setCancelled(true);
-            }
+        if (!plugin.getConfig().getBoolean("AntiSpamCommands"))
+            return;
+        if (plugin.getConfig().getBoolean("AntiSpamCommandsUseWhitelist")
+                && plugin.getConfig().getStringList("AntiSpamCommandsWhitelist").stream().noneMatch(s -> event.getMessage().toLowerCase().startsWith(s.toLowerCase())))
+            return;
+        if (handleChatSpam(event.getPlayer(), event.getMessage())) {
+            event.setCancelled(true);
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -95,6 +95,15 @@ AntiSpamMessagesPerTime: 10 # ~1 message every 3 seconds if constantly spamming
 AntiSpamWordTime: 60
 AntiSpamLinkTime: 300
 AntiSpamCommands: true # Use the same antispam options for commands aswell.
+AntiSpamCommandsUseWhitelist: false
+AntiSpamCommandsWhitelist:
+  - /msg
+  - /message
+  - /r
+  - /reply
+  - /w
+  - /whisper
+  - /tell
 CharacterLimit: 128
 PreventUnicodeDot: true
 MoreLenientLinkCheck: true # Won't get triggered by just the word discord and dc


### PR DESCRIPTION
The PR adds list of commands to be used for anti spam feature.
It fixes the issue when a player uses commands like /2fa or /email and they are getting blocked by the anti spam.
I used two ifs for the code clarity. This could be replaced with one if you wish