### PR TITLE
Fix lag with large meta always being checked

### DIFF
--- a/src/main/java/me/moomoo/anarchyexploitfixes/Main.java
+++ b/src/main/java/me/moomoo/anarchyexploitfixes/Main.java
@@ -267,7 +267,7 @@ public class Main extends JavaPlugin implements Listener {
                 }
             }
 
-            if (getConfig().getBoolean("RemoveSpawnEggs") && item.getItemMeta() instanceof SpawnEggMeta)
+            if (getConfig().getBoolean("RemoveSpawnEggs") && item.getType() == Material.MONSTER_EGG)
                 item.subtract(item.getAmount());
 
             if (getConfig().getStringList("BANNED_BLOCKS").contains(item.getType().name()))


### PR DESCRIPTION
Checking the type is a lot faster and easier as for comparing meta every data thing has to be converted to craftbukkit classes. That's slow for books and shulkers.