### PR TITLE
Fix Nullpointer Exception in 1.19+

### DIFF
--- a/src/main/java/me/moomoo/anarchyexploitfixes/patches/ProtocolLib.java
+++ b/src/main/java/me/moomoo/anarchyexploitfixes/patches/ProtocolLib.java
@@ -14,6 +14,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.entity.Boat;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -94,25 +96,27 @@ public class ProtocolLib {
                                 return;
                             }
 
-                            Player e = event.getPlayer();
-                            if (e.isInsideVehicle() && e.getVehicle().getType() == EntityType.BOAT) {
-                                if (boatLevels.get(e.getUniqueId()) != null) {
-                                    if (boatLevels.get(e.getUniqueId()) > plugin.getConfig().getInt("MaxEntityPacketsPer10Seconds")) {
+                            Player player = event.getPlayer();
+                            Entity vehicle = player.getVehicle();
+
+                            if (vehicle instanceof Boat) {
+                                if (boatLevels.get(player.getUniqueId()) != null) {
+                                    if (boatLevels.get(player.getUniqueId()) > plugin.getConfig().getInt("MaxEntityPacketsPer10Seconds")) {
                                         new BukkitRunnable() {
                                             public void run() {
-                                                e.getVehicle().remove();
+                                                vehicle.remove();
                                             }
                                         }.runTask(plugin);
                                         if (plugin.getConfig().getBoolean("LogBoatFlyEvents")) {
-                                            plugin.getLogger().warning(e.getName() + " prevented from boatflying");
+                                            plugin.getLogger().warning(player.getName() + " prevented from boatflying");
                                         }
                                     } else {
-                                        boatLevels.merge(e.getUniqueId(), 1, Integer::sum);
-                                        Bukkit.getServer().getScheduler().runTaskLater(plugin, () -> boatLevels.put(e.getUniqueId(), boatLevels.get(e.getUniqueId()) - 1), 200L);
+                                        boatLevels.merge(player.getUniqueId(), 1, Integer::sum);
+                                        Bukkit.getServer().getScheduler().runTaskLater(plugin, () -> boatLevels.put(player.getUniqueId(), boatLevels.get(player.getUniqueId()) - 1), 200L);
                                     }
                                 } else {
-                                    boatLevels.put(e.getUniqueId(), 1);
-                                    Bukkit.getServer().getScheduler().runTaskLater(plugin, () -> boatLevels.put(e.getUniqueId(), boatLevels.get(e.getUniqueId()) - 1), 200L);
+                                    boatLevels.put(player.getUniqueId(), 1);
+                                    Bukkit.getServer().getScheduler().runTaskLater(plugin, () -> boatLevels.put(player.getUniqueId(), boatLevels.get(player.getUniqueId()) - 1), 200L);
                                 }
 
                             }


### PR DESCRIPTION
Fixes: 

```
[14:06:45 WARN]: [AnarchyExploitFixes] Task #795094 for AnarchyExploitFixes v1.27.0 generated an exception
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Entity.remove()" because the return value of "org.bukkit.entity.Player.getVehicle()" is null
        at me.moomoo.anarchyexploitfixes.patches.ProtocolLib$3$1.run(ProtocolLib.java:103) ~[anarchyexploitfixes-1.27.0.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1500) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:486) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1424) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1194) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:310) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
[14:06:45 WARN]: [AnarchyExploitFixes] Task #795095 for AnarchyExploitFixes v1.27.0 generated an exception
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Entity.remove()" because the return value of "org.bukkit.entity.Player.getVehicle()" is null
        at me.moomoo.anarchyexploitfixes.patches.ProtocolLib$3$1.run(ProtocolLib.java:103) ~[anarchyexploitfixes-1.27.0.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1500) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:486) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1424) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1194) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:310) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
[14:06:45 WARN]: [AnarchyExploitFixes] Task #795096 for AnarchyExploitFixes v1.27.0 generated an exception
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Entity.remove()" because the return value of "org.bukkit.entity.Player.getVehicle()" is null
        at me.moomoo.anarchyexploitfixes.patches.ProtocolLib$3$1.run(ProtocolLib.java:103) ~[anarchyexploitfixes-1.27.0.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1500) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:486) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1424) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1194) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:310) ~[purpur-1.19.2.jar:git-Purpur-1842]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

When using BoatFly patch in 1.19+