### PR TITLE
fixing the french translation

### DIFF
--- a/src/main/resources/lang/fr_fr.yml
+++ b/src/main/resources/lang/fr_fr.yml
@@ -18,7 +18,7 @@ elytra:
       speed: "&7Vitesse: %speed% / %maxspeed%"
       disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le TPS est inférieur à %tps%."
       going-too-fast-low-tps: "&cLa vitesse des Elytras est réduite en cas de TPS faible. Baissez votre vitesse."
-      going-too-fast-chunkinfo: "&cBaissez votre vitesse. La vitesse des Elytras est limitée dans %neworold% %chunks%."
+      going-too-fast-chunkinfo: "&cBaissez votre vitesse. La vitesse des Elytras est limitée dans les %neworold% %chunks%."
       going-too-fast: "&cBaissez votre vitesse. La vitesse des Elytras est limitée sur ce serveur."
     nether-ceiling:
       disabled-here: "&cLes Elytras sont désactivées sur le plafond du Nether."
@@ -31,7 +31,7 @@ elytra:
       speed: "&7Vitesse: %speed% / %maxspeed%"
       disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le TPS est inférieur à %tps%."
       going-too-fast-low-tps: "&cLa vitesse des Elytras est réduite en cas de TPS faible. Baissez votre vitesse."
-      going-too-fast-chunkinfo: "&cBaissez votre vitesse. La vitesse des Elytras est limitée dans %neworold% %chunks%."
+      going-too-fast-chunkinfo: "&cBaissez votre vitesse. La vitesse des Elytras est limitée dans les %neworold% %chunks%."
       going-too-fast: "&cBaissez votre vitesse. La vitesse des Elytras est limitée sur le plafond du Nether."
     spawn:
       disabled-here: "&cLes Elytras sont désactivées dans un rayon de &6%radius% &cblocs autour du spawn."
@@ -63,6 +63,6 @@ command-whitelist:
 kicks:
   masked-kick-message: "&6Déconnecté"
 1b1t-options:
-  you-need-to-be-x-blocks-away-to-tp: "&9Vous devez être à %blocks% blocs du spawn pour se téléporter!"
+  you-need-to-be-x-blocks-away-to-tp: "&9Vous devez être à %blocks% blocs du spawn pour vous téléporter !"
   nickname-reset-only: "&9Vous ne pouvez pas changer votre pseudo, mais vous pouvez le réinitialiser en tapant /nick off si vous avez un pseudo hérité!"
   not-worldsize: "&7Ce n'est pas la taille du monde, pour connaître la taille du monde tapez /stats."

--- a/src/main/resources/lang/fr_fr.yml
+++ b/src/main/resources/lang/fr_fr.yml
@@ -1,68 +1,68 @@
 TRANSLATION:
-  AUTHOR: ChatGPT
+  AUTHOR: ChatGPT, edited by CAEC64
   LANGUAGE: European French
   LOCALE: fr_fr
 
 no-permission: "&cVous n'avez pas la permission d'utiliser cette commande."
 elytra:
-  disable-packet-elytrafly: "&cDésactiver le vol avec Elytra par paquet."
+  disable-packet-elytrafly: "&cDésactiver l'Elytra Fly par paquets."
   elytra-speed:
     global:
       disabled-here: "&cLes Elytras sont actuellement désactivées."
       you-are-flying-in: "&7Vous volez dans %neworold% &7%chunks%."
-      new: "nouveau"
+      new: "nouveaux"
       color-newchunks: "&4"
       old: "vieux"
       color-oldchunks: "&a"
-      chunks: "morceaux"
+      chunks: "chunks"
       speed: "&7Vitesse: %speed% / %maxspeed%"
-      disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le tps est inférieur à %tps%."
-      going-too-fast-low-tps: "&cLa vitesse des Elytras est réduite en cas de tps faible. Baissez vos paramètres."
-      going-too-fast-chunkinfo: "&cBaissez vos paramètres. La vitesse des Elytras est limitée dans %neworold% %chunks%."
-      going-too-fast: "&cBaissez vos paramètres. La vitesse des Elytras est limitée sur ce serveur."
+      disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le TPS est inférieur à %tps%."
+      going-too-fast-low-tps: "&cLa vitesse des Elytras est réduite en cas de TPS faible. Baissez votre vitesse."
+      going-too-fast-chunkinfo: "&cBaissez votre vitesse. La vitesse des Elytras est limitée dans %neworold% %chunks%."
+      going-too-fast: "&cBaissez votre vitesse. La vitesse des Elytras est limitée sur ce serveur."
     nether-ceiling:
       disabled-here: "&cLes Elytras sont désactivées sur le plafond du Nether."
       you-are-flying-in: "&7Vous volez dans %neworold% &7%chunks%."
-      new: "nouveau"
+      new: "nouveaux"
       color-newchunks: "&4"
       old: "vieux"
       color-oldchunks: "&a"
-      chunks: "morceaux de plafond"
+      chunks: "chunks du plafond"
       speed: "&7Vitesse: %speed% / %maxspeed%"
-      disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le tps est inférieur à %tps%."
-      going-too-fast-low-tps: "&cLa vitesse des Elytras est réduite en cas de tps faible. Baissez vos paramètres."
-      going-too-fast-chunkinfo: "&cBaissez vos paramètres. La vitesse des Elytras est limitée dans %neworold% %chunks%."
-      going-too-fast: "&cBaissez vos paramètres. La vitesse des Elytras est limitée sur le plafond du Nether."
+      disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le TPS est inférieur à %tps%."
+      going-too-fast-low-tps: "&cLa vitesse des Elytras est réduite en cas de TPS faible. Baissez votre vitesse."
+      going-too-fast-chunkinfo: "&cBaissez votre vitesse. La vitesse des Elytras est limitée dans %neworold% %chunks%."
+      going-too-fast: "&cBaissez votre vitesse. La vitesse des Elytras est limitée sur le plafond du Nether."
     spawn:
-      disabled-here: "&cLes Elytras sont désactivées dans un rayon de &6%radius% &cblocs autour de la génération."
+      disabled-here: "&cLes Elytras sont désactivées dans un rayon de &6%radius% &cblocs autour du spawn."
       you-are-flying-in: "&7Vous volez dans %neworold% &7%chunks%."
-      new: "nouveau"
+      new: "nouveaux"
       color-newchunks: "&4"
       old: "vieux"
       color-oldchunks: "&a"
-      chunks: "morceaux de génération"
+      chunks: "chunks du spawn"
       speed: "&7Vitesse: %speed% / %maxspeed%"
-      disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le tps est inférieur à %tps%."
-      going-too-fast-chunkinfo: "&cLa vitesse des Elytras dans %neworold% %chunks% est limitée dans un rayon de %radius% blocs autour de la génération."
-      going-too-fast: "&cLa vitesse des Elytras est limitée dans un rayon de %radius% autour de la génération."
+      disabled-low-tps: "&cLes Elytras sont actuellement désactivées car le TPS est inférieur à %tps%."
+      going-too-fast-chunkinfo: "&cLa vitesse des Elytras dans %neworold% %chunks% est limitée dans un rayon de %radius% blocs autour du spawn."
+      going-too-fast: "&cLa vitesse des Elytras est limitée dans un rayon de %radius% autour du spawn."
 redstone:
   stop-spamming-levers: "&cArrêtez de spammer les leviers."
 join-leave-messages:
   join: "&7%player% a rejoint le jeu."
   leave: "&7%player% a quitté le jeu."
   # %players_num% is how many players have joined the server formatted to ordinal (ex. 351st). Ordinal format will switch based on locale.
-  first-join: "&6%player% a rejoint le jeu pour la première fois. Ils sont le %players_num% joueur à rejoindre."
+  first-join: "&6%player% est le %players_num% joueur à rejoindre le serveur pour la première fois."
   enabled-connection-msgs: "&aMessages de connexion activés"
   disabled-connection-msgs: "&cMessages de connexion désactivés"
 chat:
   chatco-fix-specify-player: "&cVous n'avez pas ajouté de nom de joueur..."
 withers:
-  disabled-at-spawn: "&4La génération de Wither est désactivée dans un rayon de %radius% blocs autour de la génération."
+  disabled-at-spawn: "&4L'apparition de Wither est désactivée dans un rayon de %radius% blocs autour du spawn."
 command-whitelist:
   bad-command: "&4Mauvaise commande. Tapez /help pour obtenir une liste de commandes."
 kicks:
   masked-kick-message: "&6Déconnecté"
 1b1t-options:
-  you-need-to-be-x-blocks-away-to-tp: "&9Vous devez être à %blocks% blocs de la génération pour téléporter!"
+  you-need-to-be-x-blocks-away-to-tp: "&9Vous devez être à %blocks% blocs du spawn pour se téléporter!"
   nickname-reset-only: "&9Vous ne pouvez pas changer votre pseudo, mais vous pouvez le réinitialiser en tapant /nick off si vous avez un pseudo hérité!"
   not-worldsize: "&7Ce n'est pas la taille du monde, pour connaître la taille du monde tapez /stats."


### PR DESCRIPTION
some words were unnecessarily changed by chatgpt such as "spawn" or "chunks" so i reverted them back because french players use those words anyways. also i did some other changes, it's mostly about making the sentences more coherent and things like adding an extra x to "nouveau" because it's the chunks we're talking about (plural).