### PR TITLE
Fix end portal NoSuchMethod error on higher Minecraft version

### DIFF
--- a/AnarchyExploitFixesLegacy/src/main/java/me/moomoo/anarchyexploitfixes/modules/preventions/portals/EndPortalDestruction.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/moomoo/anarchyexploitfixes/modules/preventions/portals/EndPortalDestruction.java
@@ -5,6 +5,7 @@ import me.moomoo.anarchyexploitfixes.AnarchyExploitFixes;
 import me.moomoo.anarchyexploitfixes.config.Config;
 import me.moomoo.anarchyexploitfixes.modules.AnarchyExploitFixesModule;
 import me.moomoo.anarchyexploitfixes.utils.LogUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -167,6 +168,9 @@ public class EndPortalDestruction implements AnarchyExploitFixesModule,Listener 
     }
 
     private boolean isEndPortal(Material material) {
-        return material.equals(Material.ENDER_PORTAL) || material.equals(Material.ENDER_PORTAL_FRAME);
+        if (Bukkit.getVersion().contains("1.12")) {
+            return material.equals(Material.ENDER_PORTAL) || material.equals(Material.ENDER_PORTAL_FRAME);
+        }
+        return material.equals(Material.getMaterial("END_PORTAL")) || material.equals(Material.getMaterial("END_PORTAL_FRAME"));
     }
 }


### PR DESCRIPTION
The block Material name of "end portal" and "end portal frame" in 1.12.2 Paper API is different within the higher version API.

And I made a conditional check to make it compatible with higher version API.