### PR TITLE
Add logging/kick to TagParser crash detection

### DIFF
--- a/AnarchyExploitFixesFolia/src/main/java/me/moomoo/anarchyexploitfixes/modules/packets/AntiTagParserCrash.java
+++ b/AnarchyExploitFixesFolia/src/main/java/me/moomoo/anarchyexploitfixes/modules/packets/AntiTagParserCrash.java
@@ -7,16 +7,23 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientTabComplete;
 import me.moomoo.anarchyexploitfixes.AnarchyExploitFixes;
+import me.moomoo.anarchyexploitfixes.config.Config;
 import me.moomoo.anarchyexploitfixes.modules.AEFModule;
 import org.bukkit.entity.Player;
 
 public class AntiTagParserCrash extends PacketListenerAbstract implements AEFModule {
 
+    private final AnarchyExploitFixes plugin;
     private static final String[] ABUSABLE_SEQUENCES = { "@", "[", "nbt", "=", "{", "}", "]" };
+    private final boolean logIsEnabled, shouldKickPlayer;
 
     public AntiTagParserCrash() {
         super(PacketListenerPriority.HIGHEST);
         shouldEnable();
+        this.plugin = AnarchyExploitFixes.getInstance();
+        Config config = AnarchyExploitFixes.getConfiguration();
+        this.logIsEnabled = config.getBoolean(configPath() + ".log", true);
+        this.shouldKickPlayer = config.getBoolean(configPath() + ".kick-player", false);
         AnarchyExploitFixes.getConfiguration().addComment(configPath() + ".enable", "Patches TagParser crash exploit.");
     }
 
@@ -68,5 +75,10 @@ public class AntiTagParserCrash extends PacketListenerAbstract implements AEFMod
                 event.setCancelled(true);
             }
         }
+
+        if (logIsEnabled)
+            info("Prevented player '"+player.getName()+"' from using TagParser crash.");
+        if (shouldKickPlayer)
+            player.getScheduler().run(plugin, kick -> player.kick(AnarchyExploitFixes.getLang(player.locale()).misc_MaskedKickMessage), null);
     }
 }

--- a/AnarchyExploitFixesLegacy/src/main/java/me/moomoo/anarchyexploitfixes/modules/packets/AntiTagParserCrash.java
+++ b/AnarchyExploitFixesLegacy/src/main/java/me/moomoo/anarchyexploitfixes/modules/packets/AntiTagParserCrash.java
@@ -7,16 +7,23 @@ import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientTabComplete;
 import me.moomoo.anarchyexploitfixes.AnarchyExploitFixes;
+import me.moomoo.anarchyexploitfixes.config.Config;
 import me.moomoo.anarchyexploitfixes.modules.AEFModule;
 import org.bukkit.entity.Player;
 
 public class AntiTagParserCrash extends PacketListenerAbstract implements AEFModule {
 
+    private final AnarchyExploitFixes plugin;
     private static final String[] ABUSABLE_SEQUENCES = { "@", "[", "nbt", "=", "{", "}", "]" };
+    private final boolean logIsEnabled, shouldKickPlayer;
 
     public AntiTagParserCrash() {
         super(PacketListenerPriority.HIGHEST);
         shouldEnable();
+        this.plugin = AnarchyExploitFixes.getInstance();
+        Config config = AnarchyExploitFixes.getConfiguration();
+        this.logIsEnabled = config.getBoolean(configPath() + ".log", true);
+        this.shouldKickPlayer = config.getBoolean(configPath() + ".kick-player", false);
         AnarchyExploitFixes.getConfiguration().addComment(configPath() + ".enable", "Patches MojangParser/TagParser crash exploit.");
     }
 
@@ -63,5 +70,10 @@ public class AntiTagParserCrash extends PacketListenerAbstract implements AEFMod
                 event.setCancelled(true);
             }
         }
+
+        if (logIsEnabled)
+            info("Prevented player '"+player.getName()+"' from using TagParser crash.");
+        if (shouldKickPlayer)
+            plugin.getServer().getScheduler().runTask(plugin, () -> player.kickPlayer(AnarchyExploitFixes.getLang(player.getLocale()).misc_MaskedKickMessage));
     }
 }

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ patches:
   tag-parser-crash-patch:
     # Patches TagParser crash exploit.
     enable: true
+    log: true
+    kick-player: false
 
 #################
 #  Preventions  #


### PR DESCRIPTION
This adds log + kick functionality to the `AntiTagParserCrash` detection. Code was copied from another module for consistency.

We've had a bunch of people using this exploit to crash our server and found your plugin from forums. Since using it, players are no longer able to crash the server (which is awesome!) but I would now like to know when someone _attempts_ it so we can deal with them.

Also just a huge thank you for all the many great exploit fixes in your plugin!

